### PR TITLE
Update CI actions to Node 24

### DIFF
--- a/.github/workflows/build-and-zip.yml
+++ b/.github/workflows/build-and-zip.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -43,7 +43,7 @@ jobs:
           zip -r ../hs-nav.zip .
 
       - name: Upload zip artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hs-nav
           path: hs-nav.zip


### PR DESCRIPTION
## Summary

Update the pinned GitHub Actions revisions to official Node.js 24 releases:

- `actions/checkout` v6.0.2
- `actions/setup-node` v6.4.0
- `actions/upload-artifact` v7.0.1

## Why

The v2.0.0 tag workflow passed but reported that the previous action revisions target deprecated Node.js 20. This removes that warning before the GitHub Release is published.

## Impact

CI behavior remains the same: install with Node.js 22, run `npm run check`, create `hs-nav.zip`, and upload the artifact.

## Validation

- workflow YAML parsed successfully
- immutable release tags resolved to their official commit SHAs
- `git diff --check`
- GitHub Actions must pass before merge
